### PR TITLE
Fixes PHP Strict Mode Warning.

### DIFF
--- a/lib/ns_tmo_plugin.class.php
+++ b/lib/ns_tmo_plugin.class.php
@@ -93,7 +93,7 @@ class NS_TMO_Plugin {
 	/**
 	 *
 	*/
-	public function get_instance () {
+	public static function get_instance () {
 		
 		if (empty(self::$instance)) {
 			


### PR DESCRIPTION
The singleton `get_instance` function caused warnings in PHP strict mode.
For more see here: https://github.com/billerickson/Term-Menu-Order/issues/3
